### PR TITLE
Update documentation for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You should be done now! To review what we’ve done for you, be sure to do a `gi
 ### Running the Example Test
 
 1. Open `test/system/basics_test.rb` in your editor of choice.
-2. Run `MAGIC_TEST=1 rails test:system test/system/basics_test.rb` on the shell.
+2. Run `MAGIC_TEST=1 rails test test/system/basics_test.rb` on the shell.
 
 This results in three windows:
 


### PR DESCRIPTION
Running `MAGIC_TEST=1 rails test:system test/system/basic_system_test.rb` will run all the system tests, because that task doesn't support the command line arg to run a single test. It will get to the magic_test statement eventually, but it takes a while and can be a bit disorienting to see everything fly by in the browser.  

Using regular `rails test` will run allow you to specify a single system test with the command line argument.