### PR TITLE
Rails 5 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       capybara (>= 3.0)
       pry
       pry-stack_explorer
-      rails (>= 6.0)
+      rails (>= 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/magic_test.gemspec
+++ b/magic_test.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
   spec.add_dependency "pry-stack_explorer"
   spec.add_dependency "capybara", ">= 3.0"
-  spec.add_dependency "rails", ">= 6.0"
+  spec.add_dependency "rails", ">= 5.0"
 end


### PR DESCRIPTION
This relaxes the dependency on `rails` from `>= 6.0` to `>= 5.0`.

Everything seems to Just Work.

Fixes #59.