### PR TITLE
Support ok on windows

### DIFF
--- a/lib/magic_test/support.rb
+++ b/lib/magic_test/support.rb
@@ -121,7 +121,7 @@ module MagicTest
     def get_last_caller(caller)
       caller.select { |s| s.include?("/test/") || s.include?("/spec/") }
         .reject { |s| s.include?("helper") }
-        .first.split(":").first(2)
+        .first.match(/^(.+):(\d+):.*$/).to_a.last(2)
     end
   end
 end


### PR DESCRIPTION
Absolute paths in windows include the drive letter, (`C:\foo\bar`), which adds another colon in the path.

Caller always returns the calls in the format of `path:line number:`, so we can safely match those directly with regex and return them, regardless of platform.