### PR TITLE
Feature/add binstub executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ You should be done now! To review what we’ve done for you, be sure to do a `gi
 1. Open `test/system/basics_test.rb` in your editor of choice.
 2. Run `MAGIC_TEST=1 rails test test/system/basics_test.rb` on the shell.
 
+> Note: Using binstubs
+>
+> After you install Magic Test, in your Rails application run `bundle binstubs magic_test` and it will install an executable that will allow you to write `bin/magic [test/spec] [path/to/file]` and it will implicitly pass the `MAGIC_TEST=1` environment variable.
+>
+> Example: `bin/magic test test/system/basics_test.rb`
+
 This results in three windows:
 
   1. **A debugger** where you can interactively write Capybara test code in the same context it would normally run.

--- a/exe/magic
+++ b/exe/magic
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+test_spec = ARGV[0]
+file_path = ARGV[1]
+
+system("MAGIC_TEST=1 rails #{test_spec} #{file_path}")

--- a/exe/magic
+++ b/exe/magic
@@ -1,6 +1,38 @@
 #!/usr/bin/env ruby
 
-test_spec = ARGV[0]
+option = ARGV[0]
 file_path = ARGV[1]
 
-system("MAGIC_TEST=1 rails #{test_spec} #{file_path}")
+def run_magic_test(suite, option, file_path)
+  system("MAGIC_TEST=1 #{suite} #{option} #{file_path}")
+end
+
+case option
+when 'test'
+  suite = 'rails'
+  run_magic_test(suite, option, file_path)
+when 'spec'
+  suite = 'rspec'
+  run_magic_test(suite, option, file_path)
+when '--help'
+  help_info = %q(
+    Usage: `bin/magic [option] [path/to/file]`
+
+    option = 'test' # will run MiniTest
+    option = 'spec' # will run RSpec
+
+    Assign `file_path` to the path of the file you want to test
+
+    Each run will implicitly pass the `MAGIC_TEST=1` environment variable in order to run Magic Test and it's debugger
+  )
+
+  puts help_info
+else
+  quick_tip = %q(
+    To run Magic Test: `bin/magic [option] [path/to/file.rb]`
+
+    Run `bin/magic --help` for more information
+  )
+  
+  puts quick_tip
+end


### PR DESCRIPTION
For one of my first features I wanted to create an executable that would make running Magic Tests a lot less verbose, since it is a command that would need to be done in repetition. Other testing suites have smaller, cleaner user-friendly commands and I just wanted to convey that how developers interact with the gem in their workflow is just as important as the features that Magic Test itself has to offer.

After installing Magic Test you can run `bundle binstubs magic_test` from your Rails app and it will add the `magic` executable in your `bin` folder.

The executable takes into consideration both MiniTest and RSpec and implicitly passes the `MAGIC_TEST=1` environment variable in the command to run the debugger.

The format looks like: `bin/magic [option] [path/to/file.rb]`
You can run a MiniTest test with: `bin/magic test test/system/basics_test.rb`
and an RSpec spec with: `bin/magic spec spec/system/basics_spec.rb`