### PR TITLE
Feature/assertion improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ With this we will:
 
  - Create a sample system test at `test/system/basics_test.rb` that invokes Magic Test.
  - If your application was previously configured to run system tests with `:headless_chrome` or `:headless_firefox`, we will attempt to update your configuration so you can see the browser when you run tests with `MAGIC_TEST=1` as an environment variable.
+ - Viewing Magic Test with your browser, editor, and terminal in view is the best experience. The generator also attempts to update the browser dimensions to open to the left at a narrower width, so you don't need to keep readjusting your windows after your initial adjustment.
 
  Finally, because it’s hard for us to do automatically, you will need to add the following before any closing `</head>` tags in any of the files in `app/views/layouts`:
 
@@ -56,9 +57,11 @@ You should be done now! To review what we’ve done for you, be sure to do a `gi
 
 > Note: Using binstubs
 >
-> After you install Magic Test, in your Rails application run `bundle binstubs magic_test` and it will install an executable that will allow you to write `bin/magic [test/spec] [path/to/file]` and it will implicitly pass the `MAGIC_TEST=1` environment variable.
+> After you install Magic Test, you can now run `bundle binstubs magic_test` in your Rails application and it will install an executable that will allow you to write `bin/magic [test/spec] [path/to/file]` and it will implicitly pass the `MAGIC_TEST=1` environment variable.
 >
 > Example: `bin/magic test test/system/basics_test.rb`
+>
+> After running binstubs you can type: `bin/magic --help` for more info.
 
 This results in three windows:
 
@@ -89,7 +92,9 @@ You can click on buttons, click on links, fill in forms, and do many other thing
 
 ### Generating Assertions in the Browser
 
-If you want to add an assertion that some content exists on the page, simply highlight some text and press <kbd>Control</kbd><kbd>Shift</kbd> + <kbd>A</kbd>. You should see an alert dialog confirming the assertion has been generated.
+If you want to add an assertion that some content exists on the page, simply highlight some text and press <kbd>Control</kbd><kbd>Shift</kbd> + <kbd>A</kbd> and you should see a confirm dialog to generate the assertion or a cancel button which will not generate an assertion and allow you to reselect new text in case the content was incorrectly highlighted. 
+
+You can now also generate an assertion by right-clicking on the selected text with your mouse or touchpad for a quicker workflow.
 
 ### Flushing In Browser Actions and Assertions to the Test File
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ You should be done now! To review what we’ve done for you, be sure to do a `gi
 1. Open `test/system/basics_test.rb` in your editor of choice.
 2. Run `MAGIC_TEST=1 rails test test/system/basics_test.rb` on the shell.
 
+> Note: Using binstubs
+>
+> After you install Magic Test, in your Rails application run `bundle binstubs magic_test` and it will install an executable that will allow you to write `bin/magic [test/spec] [path/to/file]` and it will implicitly pass the `MAGIC_TEST=1` environment variable.
+>
+> Example: `bin/magic test test/system/basics_test.rb`
+
 This results in three windows:
 
   1. **A debugger** where you can interactively write Capybara test code in the same context it would normally run.

--- a/app/views/magic_test/_context_menu.html
+++ b/app/views/magic_test/_context_menu.html
@@ -53,7 +53,7 @@
         var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
         var target = "";
         var options = "";
-        var accept = "Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file."
+        var accept = "You selected:\n\r" + text + "\n\rOk: Type `flush` into debugger console to add to test.\nCancel: To select new text."
         if (window.confirm(accept)) {
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));

--- a/app/views/magic_test/_context_menu.html
+++ b/app/views/magic_test/_context_menu.html
@@ -13,24 +13,15 @@
 
 
   function enableKeyboardShortcuts() {
-    /*
+    // Ctrl+A to generate an assertion
     function keydown(event) {
       if (event.ctrlKey && event.shiftKey && event.key === 'A') {
         event.preventDefault();
         generateAssertion();
       }
     }
-    */
 
-    function riteklick(event) {
-      if (event.button == 2) {
-        setupAssertion();
-        window.addEventListener("contextmenu", e => e.preventDefault());
-      }
-    }
-
-    // document.addEventListener('keydown', keydown, false);
-    document.addEventListener('mousedown', riteklick);
+    document.addEventListener('keydown', keydown, false);
 
     function generateAssertion() {
       var text = selectedText().trim();
@@ -44,17 +35,32 @@
         alert("Generated an assertion for \"" + selectedText() + "\". Type `flush` in the debugger console to add it to your test file.");
       }
     }
+   
+    // Right-click to generate an assertion
+    function riteklick(event) {
+      if (event.button == 2) {
+        window.addEventListener("contextmenu", e => e.preventDefault());
+        setupAssertion(event);
+      }
+    }
+    
+    document.addEventListener('mousedown', riteklick);
 
-    function setupAssertion() {
+    function setupAssertion(event) {
       var text = selectedText().trim();
       if (text.length > 0) {
         var action = "assert page.has_content? '" + text.replace("'", "\\\'") + "'";
         var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
         var target = "";
         var options = "";
-        testingOutput.push({action: action, target: target, options: options});
-        sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
-        alert("Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file.")
+        var accept = "Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file."
+        if (window.confirm(accept)) {
+          testingOutput.push({action: action, target: target, options: options});
+          sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
+        }
+        else {
+          console.log("Assertion was not generated.")
+        }
       }
     }
 

--- a/app/views/magic_test/_context_menu.html
+++ b/app/views/magic_test/_context_menu.html
@@ -13,14 +13,24 @@
 
 
   function enableKeyboardShortcuts() {
+    /*
     function keydown(event) {
       if (event.ctrlKey && event.shiftKey && event.key === 'A') {
         event.preventDefault();
         generateAssertion();
       }
     }
+    */
 
-    document.addEventListener('keydown', keydown, false);
+    function riteklick(event) {
+      if (event.button == 2) {
+        setupAssertion();
+        window.addEventListener("contextmenu", e => e.preventDefault());
+      }
+    }
+
+    // document.addEventListener('keydown', keydown, false);
+    document.addEventListener('mousedown', riteklick);
 
     function generateAssertion() {
       var text = selectedText().trim();
@@ -32,6 +42,19 @@
         testingOutput.push({action: action, target: target, options: options});
         sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
         alert("Generated an assertion for \"" + selectedText() + "\". Type `flush` in the debugger console to add it to your test file.");
+      }
+    }
+
+    function setupAssertion() {
+      var text = selectedText().trim();
+      if (text.length > 0) {
+        var action = "assert page.has_content? '" + text.replace("'", "\\\'") + "'";
+        var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
+        var target = "";
+        var options = "";
+        testingOutput.push({action: action, target: target, options: options});
+        sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
+        alert("Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file.")
       }
     }
 

--- a/app/views/magic_test/_context_menu.html
+++ b/app/views/magic_test/_context_menu.html
@@ -30,9 +30,14 @@
         var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
         var target = "";
         var options = "";
-        testingOutput.push({action: action, target: target, options: options});
-        sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
-        alert("Generated an assertion for \"" + selectedText() + "\". Type `flush` in the debugger console to add it to your test file.");
+        var accept = "Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file."
+        if (window.confirm(accept)) {
+          testingOutput.push({action: action, target: target, options: options});
+          sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
+        }
+        else {
+          console.log("Assertion was not generated.")
+        }
       }
     }
    
@@ -53,7 +58,7 @@
         var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
         var target = "";
         var options = "";
-        var accept = "You selected:\n\r" + text + "\n\rOk: Type `flush` into debugger console to add to test.\nCancel: To select new text."
+        var accept = "Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file."
         if (window.confirm(accept)) {
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));

--- a/app/views/magic_test/_context_menu.html
+++ b/app/views/magic_test/_context_menu.html
@@ -30,7 +30,7 @@
         var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
         var target = "";
         var options = "";
-        var accept = "Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file."
+        var accept = "You selected:\n\r" + text + "\n\rOk: Type `flush` into debugger console to add to test.\nCancel: To select new text."
         if (window.confirm(accept)) {
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
@@ -58,7 +58,7 @@
         var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
         var target = "";
         var options = "";
-        var accept = "Generated an assertion:\"" + action + "\". Type `flush` in the debugger console to add it to your test file."
+        var accept = "You selected:\n\r" + text + "\n\rOk: Type `flush` into debugger console to add to test.\nCancel: To select new text."
         if (window.confirm(accept)) {
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));

--- a/exe/magic
+++ b/exe/magic
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+test_spec = ARGV[0]
+file_path = ARGV[1]
+
+system("MAGIC_TEST=1 rails #{test_spec} #{file_path}")

--- a/exe/magic
+++ b/exe/magic
@@ -1,6 +1,38 @@
 #!/usr/bin/env ruby
 
-test_spec = ARGV[0]
+option = ARGV[0]
 file_path = ARGV[1]
 
-system("MAGIC_TEST=1 rails #{test_spec} #{file_path}")
+def run_magic_test(suite, option, file_path)
+  system("MAGIC_TEST=1 #{suite} #{option} #{file_path}")
+end
+
+case option
+when 'test'
+  suite = 'rails'
+  run_magic_test(suite, option, file_path)
+when 'spec'
+  suite = 'rspec'
+  run_magic_test(suite, option, file_path)
+when '--help'
+  help_info = %q(
+    Usage: `bin/magic [option] [path/to/file]`
+
+    option = 'test' # will run MiniTest
+    option = 'spec' # will run RSpec
+
+    Assign `file_path` to the path of the file you want to test
+
+    Each run will implicitly pass the `MAGIC_TEST=1` environment variable in order to run Magic Test and it's debugger
+  )
+
+  puts help_info
+else
+  quick_tip = %q(
+    To run Magic Test: `bin/magic [option] [path/to/file.rb]`
+
+    Run `bin/magic --help` for more information
+  )
+  
+  puts quick_tip
+end

--- a/lib/generators/magic_test/install_generator.rb
+++ b/lib/generators/magic_test/install_generator.rb
@@ -3,10 +3,6 @@ require "magic_test/engine"
 
 module MagicTest
   class InstallGenerator < Rails::Generators::Base
-    def self.source_paths
-      [MagicTest::Engine.root, File.expand_path("../templates", __FILE__)]
-    end
-
     def install
       unless defined?(MagicTest)
         gem_group :test do
@@ -14,16 +10,56 @@ module MagicTest
         end
       end
 
-      generate "system_test", "basic"
+      setup_test_example
+      update_app_test_case
+      insert_magic_test_partial
+      install_message
+    end
+
+    private
+
+    def setup_test_example
+      generate 'system_test', 'basic'
       gsub_file "test/system/basics_test.rb", "# ", ""
       gsub_file "test/system/basics_test.rb", "#", ""
       gsub_file "test/system/basics_test.rb", "visiting the index", "getting started"
       gsub_file "test/system/basics_test.rb", "visit basics_url", "visit root_path"
       gsub_file "test/system/basics_test.rb", 'assert_selector "h1", text: "Basic"', "magic_test"
+    end
 
+    def update_app_test_case
+      gsub_file "test/application_system_test_case.rb", "using: :chrome", "using: :headless_chrome"
+      gsub_file "test/application_system_test_case.rb", "using: :firefox", "using: :headless_firefox"
       gsub_file "test/application_system_test_case.rb", "using: :headless_chrome", "using: (ENV['MAGIC_TEST'] ? :chrome : :headless_chrome)"
       gsub_file "test/application_system_test_case.rb", "using: :headless_firefox", "using: (ENV['MAGIC_TEST'] ? :firefox : :headless_firefox)"
       gsub_file "test/application_system_test_case.rb", "screen_size: [1400, 1400]", "screen_size: (ENV['MAGIC_TEST'] ? [800, 1400] : [1400, 1400])"
+    end
+
+    def insert_magic_test_partial
+      templates = view_layout_templates
+      string = "    <%= render 'magic_test/support' if Rails.env.test? %>\n"
+      templates.each do |file|
+        insert_into_file file, string, before: /^\s*<\/head>/
+      end
+    end
+
+    def view_layout_templates
+      layouts = Dir.glob("#{Rails.root}/app/views/layouts/**/*.html.erb")
+      layouts.reject { |file| file =~ /mailer/ }
+    end
+
+    def install_message
+      message = %q(
+        We just inserted:
+        `<%= render 'magic_test/support' if Rails.env.test? %>`
+        before each closing `</head>` tag in your all of your templates in your `layouts` directory.
+        If there is another template or partial containing any `<head></head>` tags any where else in
+        your project (Example: `views/shared/_head.html.erb`), please paste the render snippet above within the head tags to ensure Magic Test
+        will work as expected.
+        Run your first Magic Test by typing `bin/magic test test/system/basics_test.rb` into your terminal!
+        )
+      
+      puts message
     end
   end
 end

--- a/lib/generators/magic_test/install_generator.rb
+++ b/lib/generators/magic_test/install_generator.rb
@@ -18,11 +18,12 @@ module MagicTest
       gsub_file "test/system/basics_test.rb", "# ", ""
       gsub_file "test/system/basics_test.rb", "#", ""
       gsub_file "test/system/basics_test.rb", "visiting the index", "getting started"
-      gsub_file "test/system/basics_test.rb", "visit basics_url", "visit root_url"
+      gsub_file "test/system/basics_test.rb", "visit basics_url", "visit root_path"
       gsub_file "test/system/basics_test.rb", 'assert_selector "h1", text: "Basic"', "magic_test"
 
-      gsub_file "test/application_system_test_case.rb", "using: :headless_chrome", "using: (ENV['SHOW_TESTS'] ? :chrome : :headless_chrome)"
-      gsub_file "test/application_system_test_case.rb", "using: :headless_firefox", "using: (ENV['SHOW_TESTS'] ? :firefox : :headless_firefox)"
+      gsub_file "test/application_system_test_case.rb", "using: :headless_chrome", "using: (ENV['MAGIC_TEST'] ? :chrome : :headless_chrome)"
+      gsub_file "test/application_system_test_case.rb", "using: :headless_firefox", "using: (ENV['MAGIC_TEST'] ? :firefox : :headless_firefox)"
+      gsub_file "test/application_system_test_case.rb", "screen_size: [1400, 1400]", "screen_size: (ENV['MAGIC_TEST'] ? [800, 1400] : [1400, 1400])"
     end
   end
 end


### PR DESCRIPTION
This PR includes a few new features:
- You can now run your test with `bin/magic [test] [path/to/file]` after generating binstubs in your Rails app.
- During Magic Test, a narrow browser window opens to the left to reduce readjusting working windows. Full screen browser opens when not a Magic Test.
- You can now generate an assertion by right-clicking your selected text with your mouse or touchpad and a confirm dialog gives you the opportunity to not generate an assertion by clicking cancel and selecting new text, or clicking ok and generating the assertion ready to be added to test file when typing `flush`.