### PR TITLE
Feature/add bin executable

### DIFF
--- a/exe/magic
+++ b/exe/magic
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+option = ARGV[0]
+file_path = ARGV[1]
+
+def run_magic_test(suite, option, file_path)
+  system("MAGIC_TEST=1 #{suite} #{option} #{file_path}")
+end
+
+case option
+when "test"
+  suite = "rails"
+  run_magic_test(suite, option, file_path)
+when "spec"
+  suite = "rspec"
+  run_magic_test(suite, option, file_path)
+when "--help"
+  help_info = %q(
+    Usage: `bin/magic [option] [path/to/file]`
+
+    option = 'test' # will run MiniTest
+    option = 'spec' # will run RSpec
+
+    Assign `file_path` to the path of the file you want to test
+
+    Each run will implicitly pass the `MAGIC_TEST=1` environment variable in order to run Magic Test and it's debugger
+  )
+
+  puts help_info
+else
+  quick_tip = %q(
+    To run Magic Test: `bin/magic [option] [path/to/file.rb]`
+
+    Run `bin/magic --help` for more information
+  )
+
+  puts quick_tip
+end

--- a/lib/generators/magic_test/install_generator.rb
+++ b/lib/generators/magic_test/install_generator.rb
@@ -18,7 +18,7 @@ module MagicTest
       gsub_file "test/system/basics_test.rb", "# ", ""
       gsub_file "test/system/basics_test.rb", "#", ""
       gsub_file "test/system/basics_test.rb", "visiting the index", "getting started"
-      gsub_file "test/system/basics_test.rb", "visit basics_url", "visit root_url"
+      gsub_file "test/system/basics_test.rb", "visit basics_url", "visit root_path"
       gsub_file "test/system/basics_test.rb", 'assert_selector "h1", text: "Basic"', "magic_test"
 
       gsub_file "test/application_system_test_case.rb", "using: :headless_chrome", "using: (ENV['SHOW_TESTS'] ? :chrome : :headless_chrome)"


### PR DESCRIPTION
This PR adds an executable you can use in your Rails app. Just run `bundle binstubs magic_test` and it will allow you run `bin/magic test test/system/basics_test.rb` or if you are using RSpec you can use `bin/magic spec spec/system/basics_spec.rb` and that will run a Magic Test using RSpec.

You can also run `bin/magic --help` to see details about the options.

This is going to reduce quite a few keystrokes over time for the developer, allowing them to not have to write the verbose `MAGIC_TEST=1 rails test test/system/basics_test.rb` and type the environment variable each time, since it is passed implicitly in the executable command.