### PR TITLE
Fixing Standard Ruby

### DIFF
--- a/exe/magic
+++ b/exe/magic
@@ -15,7 +15,7 @@ when "spec"
   suite = "rspec"
   run_magic_test(suite, option, file_path)
 when "--help"
-  help_info = %q(
+  help_info = "
     Usage: `bin/magic [option] [path/to/file]`
 
     option = 'test' # will run MiniTest
@@ -24,15 +24,15 @@ when "--help"
     Assign `file_path` to the path of the file you want to test
 
     Each run will implicitly pass the `MAGIC_TEST=1` environment variable in order to run Magic Test and it's debugger
-  )
+  "
 
   puts help_info
 else
-  quick_tip = %q(
+  quick_tip = '
     To run Magic Test: `bin/magic [option] [path/to/file.rb]`
 
     Run `bin/magic --help` for more information
-  )
+  '
 
   puts quick_tip
 end

--- a/lib/generators/magic_test/install_generator.rb
+++ b/lib/generators/magic_test/install_generator.rb
@@ -58,7 +58,7 @@ module MagicTest
     end
 
     def show_install_message
-      message = %q(
+      message = "
         We just inserted:
         `<%= render 'magic_test/support' if Rails.env.test? %>`
         before each closing `</head>` tag in your all of your templates in your `layouts` directory.
@@ -67,7 +67,7 @@ module MagicTest
         will work as expected.
         Run your first Magic Test by typing `MAGIC_TEST=1 rails test test/system/basics_test.rb` or generate an executable
         with `bundle binstubs magic_test` and then run `bin/magic test test/system/basics_test.rb` into your terminal!
-        )
+        "
 
       puts message
     end

--- a/lib/magic_test/support.rb
+++ b/lib/magic_test/support.rb
@@ -6,7 +6,7 @@ module MagicTest
 
       filepath, line = get_last_caller(caller)
 
-      contents = File.open(filepath).read.lines
+      contents = File.read(filepath).lines
       chunks = contents.each_slice(line.to_i - 1 + @test_lines_written).to_a
       indentation = chunks[1].first.match(/^(\s*)/)[0]
       chunks.first << indentation + "assert(page.has_content?('#{selected_text.gsub("'", "\\\\'")}'))" + "\n"
@@ -24,7 +24,7 @@ module MagicTest
     def flush
       filepath, line = get_last_caller(caller)
 
-      contents = File.open(filepath).read.lines
+      contents = File.read(filepath).lines
       chunks = contents.each_slice(line.to_i - 1 + @test_lines_written).to_a
       indentation = chunks[1].first.match(/^(\s*)/)[0]
       output = page.evaluate_script("JSON.parse(sessionStorage.getItem('testingOutput'))")
@@ -54,7 +54,7 @@ module MagicTest
       filepath, line = get_last_caller(caller)
 
       puts "(writing that to `#{filepath}`.)"
-      contents = File.open(filepath).read.lines
+      contents = File.read(filepath).lines
       chunks = contents.each_slice(line.to_i - 1 + @test_lines_written).to_a
       indentation = chunks[1].first.match(/^(\s*)/)[0]
       get_last.each do |last|
@@ -91,11 +91,11 @@ module MagicTest
 
     def magic_test_pry_hook
       Pry.hooks.add_hook(:before_session, "magic_test") do |output, binding, pry|
-        Pry.hooks.delete_hook(:before_session, 'magic_test')
-        magic_test_file_index = pry.backtrace.index{|line| line.include?(__FILE__)}
+        Pry.hooks.delete_hook(:before_session, "magic_test")
+        magic_test_file_index = pry.backtrace.index { |line| line.include?(__FILE__) }
         # walk up backtrace until finding the original caller
-        until pry.backtrace[magic_test_file_index + 1].include?(pry.last_file) do
-          pry.run_command('up')
+        until pry.backtrace[magic_test_file_index + 1].include?(pry.last_file)
+          pry.run_command("up")
         end
       end
     end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -83,9 +83,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'home/show'
+  get "home/show"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/test/dummy/test/application_system_test_case.rb
+++ b/test/dummy/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: (ENV['MAGIC_TEST'] ? :chrome : :headless_chrome), screen_size: (ENV['MAGIC_TEST'] ? [800, 1400] : [1400, 1400])
+  driven_by :selenium, using: (ENV["MAGIC_TEST"] ? :chrome : :headless_chrome), screen_size: (ENV["MAGIC_TEST"] ? [800, 1400] : [1400, 1400])
 end

--- a/test/dummy/test/system/basics_test.rb
+++ b/test/dummy/test/system/basics_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 class BasicsTest < ApplicationSystemTestCase
   test "getting started" do
     visit root_path
-  
+
     magic_test
   end
 end

--- a/test/generators/magic_test/install_generator_test.rb
+++ b/test/generators/magic_test/install_generator_test.rb
@@ -49,7 +49,7 @@ module MagicTest
       assert_file(config_file, env_var)
 
       # Ensure layouts container the render method for the partial
-      regex = /^\s*\<%= *render \'magic_test\/support\'.*\s*\<\/head>/
+      regex = /^\s*<%= *render 'magic_test\/support'.*\s*<\/head>/
 
       assert_file_contains("application.html.erb", regex)
       assert_file_contains("dashboard.html.erb", regex)


### PR DESCRIPTION
I saw #20, and I'm guessing what it means is we want to implement standard Ruby for the tests that are generated when running `flush`, etc.

In the meantime, this PR addresses the standard Ruby fixes when just running `standardrb --fix` against `main`.