### PR TITLE
Trim white space when flushing assertions

### DIFF
--- a/lib/magic_test/support.rb
+++ b/lib/magic_test/support.rb
@@ -35,7 +35,7 @@ module MagicTest
       puts "(writing that to `#{filepath}`.)"
       if output
         output.each do |last|
-          chunks.first << indentation + "#{last["action"]} #{last["target"]}#{last["options"]}" + "\n"
+          chunks.first << indentation + "#{last["action"]} #{last["target"]}#{last["options"]}".strip + "\n"
           @test_lines_written += 1
         end
         contents = chunks.flatten.join


### PR DESCRIPTION
Fixes #51.

```
pry(#<BasicsTest>)> "#{last["action"]} #{last["target"]}#{last["options"]}" + "\n"
=> "assert page.has_content? 'Foo was successfully created.' \n"
```

Since we're tagging on a new line at the end with a `+`, just calling `strip` here should suffice.