### PR TITLE
Remove unneeded else statements

### DIFF
--- a/app/views/magic_test/_context_menu.html.erb
+++ b/app/views/magic_test/_context_menu.html.erb
@@ -35,9 +35,6 @@
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
         }
-        else {
-          console.log("Assertion was not generated.")
-        }
       }
     }
 
@@ -62,9 +59,6 @@
         if (window.confirm(accept)) {
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
-        }
-        else {
-          console.log("Assertion was not generated.")
         }
       }
     }


### PR DESCRIPTION
In #96 I had added a TODO about using try...catch here, but I honestly don't think we need this else statement to begin with. We can't open the console in the test browser, and even if we could I'm not sure how this could would actually run. For that reason, I've deleted them here.