### PR TITLE
Minor fixes to JavaScript and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,7 @@ You can click on buttons, click on links, fill in forms, and do many other thing
 
 ### Generating Assertions in the Browser
 
-#### Method 1:
-If you want to add an assertion that some content exists on the page, simply highlight some text and press <kbd>Control</kbd><kbd>Shift</kbd> + <kbd>A</kbd>. You should see a confirm dialog asking for if you want to move forward with the assertion or cancel. 
-
-#### Method 2:
-You can now generate assertions by selecting your text and right-clicking with your mouse or touchpad. 
+If you want to add an assertion that some content exists on the page, simply highlight some text and right click or press <kbd>Control</kbd><kbd>Shift</kbd> + <kbd>A</kbd>. You should see a confirm dialog asking for if you want to move forward with the assertion or cancel.
 
 ### Flushing In Browser Actions and Assertions to the Test File
 

--- a/app/views/magic_test/_context_menu.html.erb
+++ b/app/views/magic_test/_context_menu.html.erb
@@ -13,7 +13,7 @@
 
 
   function enableKeyboardShortcuts() {
-    // Ctrl+A to generate an assertion
+    // Ctrl+Shift+A to generate an assertion.
     function keydown(event) {
       if (event.ctrlKey && event.shiftKey && event.key === 'A') {
         event.preventDefault();

--- a/app/views/magic_test/_mutation_observer.html
+++ b/app/views/magic_test/_mutation_observer.html
@@ -1,5 +1,4 @@
 <script>
-
   function initializeMutationObserver(){
     window.mutationObserver = new MutationObserver(function(mutations) {
       console.log("Mutation observed")
@@ -7,19 +6,17 @@
         console.log("There is no window.target element. Quitting the mutation callback function");
         return;
       }
-      var options = "";
-      var targetClass = window.target.classList[0] ? `.${window.target.classList[0]}` : ""
-      var text = window.target.innerText ? `', text: '${window.target.innerText}` : ""
-      var action = `${finderForElement(window.target)}.hover`;
+
+      // TODO: Remove this if we don't need it.
+      // var targetClass = window.target.classList[0] ? `.${window.target.classList[0]}` : ""
+      // var text = window.target.innerText ? `', text: '${window.target.innerText}` : ""
       // var action = `find('${window.target.localName}${targetClass}${text}').hover`;
-      var target = "";
+
+      var action = `${finderForElement(window.target)}.hover`;
       var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
-      testingOutput.push({action: action, target: target, options: options});
+      testingOutput.push({action: action, target: "", options: ""});
       sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
     });
-    
-    
-    
   }
 
   function mutationStart(evt) {
@@ -31,6 +28,4 @@
   function mutationEnd () {
     window.mutationObserver.disconnect();
   }
-
-
 </script>


### PR DESCRIPTION
Besides the changes I added here, the following two methods stood out to me:
1. `keyDownFunction`
2. `keyUpFunction`

There's some duplicate code here so I'd be glad to refactor some of it, but it looks like these methods aren't being used in the first place:

https://github.com/bullet-train-co/magic_test/blob/b086d2f9bdfcbbe1b3d5283fa10fd5877f73256b/app/views/magic_test/_listeners.html#L2-L3

For that reason I won't worry about it too much now, but if we just want to get rid of these methods I can go head and delete them.