### PR TITLE
Register Capypara actions for alert and confirm methods

### DIFF
--- a/app/views/magic_test/_context_menu.html.erb
+++ b/app/views/magic_test/_context_menu.html.erb
@@ -11,16 +11,20 @@
     (function() {
       var _old_alert = window.alert;
       window.alert = function() {
-        window.registerAcceptAlert = true;
-        _old_alert.apply(window, arguments);
+        if(!window.generatingAssertion) {
+          window.registerAcceptAlert = true;
+        }
+        return _old_alert.apply(window, arguments);
       };
     })();
 
     (function() {
       var _old_confirm = window.confirm;
       window.confirm = function() {
-        window.registerAcceptConfirm = true;
-        _old_confirm.apply(window, arguments);
+        if(!window.generatingAssertion) {
+          window.registerAcceptConfirm = true;
+        }
+        return _old_confirm.apply(window, arguments);
       }
     })();
 
@@ -48,6 +52,8 @@
         var target = "";
         var options = "";
         var accept = "You selected:\n\r" + text + "\n\rOk: Type `flush` into debugger console to add to test.\nCancel: To select new text."
+
+        window.generatingAssertion = true;
         if (window.confirm(accept)) {
           testingOutput.push({action: action, target: target, options: options});
           sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
@@ -55,6 +61,7 @@
         else {
           console.log("Assertion was not generated.")
         }
+        window.generatingAssertion = false;
       }
     }
 

--- a/app/views/magic_test/_context_menu.html.erb
+++ b/app/views/magic_test/_context_menu.html.erb
@@ -7,6 +7,23 @@
     }
   }
 
+    // Override the alert and confirm functions to register capybara actions.
+    (function() {
+      var _old_alert = window.alert;
+      window.alert = function() {
+        window.registerAcceptAlert = true;
+        _old_alert.apply(window, arguments);
+      };
+    })();
+
+    (function() {
+      var _old_confirm = window.confirm;
+      window.confirm = function() {
+        window.registerAcceptConfirm = true;
+        _old_confirm.apply(window, arguments);
+      }
+    })();
+
   ready(function() {
     enableKeyboardShortcuts();
   });

--- a/app/views/magic_test/_javascript_helpers.html
+++ b/app/views/magic_test/_javascript_helpers.html
@@ -32,6 +32,19 @@
     var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
     testingOutput.push({action: action, target: target, options: options });
     sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
+
+    // Register Capybara actions for `alert` and `confirm` methods.
+    if (window.registerAcceptAlert) {
+      var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
+      testingOutput.push({action: "accept_alert", target: "", options: ""})
+      sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
+      window.registerAcceptAlert = false;
+    } else if (window.registerAcceptConfirm) {
+      var testingOutput = JSON.parse(sessionStorage.getItem("testingOutput"));
+      testingOutput.push({action: "accept_confirm", target: "", options: ""})
+      sessionStorage.setItem("testingOutput", JSON.stringify(testingOutput));
+      window.registerAcceptConfirm = false;
+    }
   };
 
   function keypressFunction(evt) {


### PR DESCRIPTION
Closes #54.

This will add `accept_alert` to a test like this:

```ruby
require "application_system_test_case"

class BasicsTest < ApplicationSystemTestCase
  test "getting started" do
    visit root_path
  
    click_on 'Link to Alert'
    accept_alert
  end
end
```

We could probably do this with a block if we wanted to, but it would definitely take more work and I at least wanted to just make sure we could register alerts that were accepted when flushing the input.
